### PR TITLE
Add matches for maps and vectors

### DIFF
--- a/src/scenari/core.clj
+++ b/src/scenari/core.clj
@@ -67,7 +67,7 @@
            <eol>              = #'\r?\n'
            scenario_sentence  = #'.*'
            step_sentence      = step_keywords sentence (<eol> tab_params)?
-           sentence           = #'[a-zA-Z0-9\"./\\_\\-\\':<>é@ ]+'
+           sentence           = #'[a-zA-Z0-9\"./\\_\\-\\':<>é@ \\{\\}\\[\\]]+'
            examples           = <whitespace?> examples-keywords <eol> header row* <eol?>
            tab_params         = <whitespace?> header row* <eol?>
            <examples-keywords>= <" (kw-translations :examples) ">
@@ -111,9 +111,8 @@
                              parameter        = <'<'> parameter_name <'>'> | <'${'> parameter_name <'}'>
                              string           = <'\"'> #'[a-zA-ZáàâäãåçéèêëíìîïñóòôöõúùûüýÿæœÁÀÂÄÃÅÇÉÈÊËÍÌÎÏÑÓÒÔÖÕÚÙÛÜÝŸÆŒ0-9\\-:,./ ]+' <'\"'>
                              <data_group>     = string | map | vector
-                             map              = #'\\{[a-zA-Z0-9\\-:,./\\\" ]+\\}'
-                             elements         = (#'\".+\"|[0-9]+' <whitespace>?)*
-                             vector           = <'['> elements <']'>
+                             map              = #'\\{[a-zA-Z0-9\\-:,./\\\" \\{\\}\\[\\]]+\\}'
+                             vector           = #'\\[[a-zA-Z0-9\\-:,./\\\" \\{\\}\\[\\]]+\\]'
                              <whitespace>     = #'\\s+'
                              <value>          = #'[a-zA-Z0-9+ ]*'
                              whitespace       = #'\\s+'


### PR DESCRIPTION
J'ai fait en sorte que les maps et les vecteurs puissent être matcher pour les mettre en paramètres d'une step.

Par contre il y a des choses que je suis pas très sûr :
* J'ai mis comme type :value dans les paramètres quand on a une map ou un vecteur comme pour les string. Je sais pas trop si c'est ce type qu'il faut donner
* Lorsqu'on match des maps (ou vecteurs), le regex va permetttre de pouvoir faire des maps imbriqués, par contre il n'y a pas de verification qu'il y a le bon nombre d'accolade fermante par rapport au nombre d'accolade ouvrante.
* Pour le match des vecteurs, j'ai enlever "elements" car ça faisait une liste [:elements <string> <string> ...], et donc impossible de faire un read-string dessus pour la transformer avec le bon type