### PR TITLE
Fix/kaocha load phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ By defining a test type in your kaocha configuration file (`tests.edn` by defaul
                   :type                              :kaocha.type/scenari
                   :kaocha/source-paths               ["src"]
                   :kaocha/test-paths                 ["test/scenario"]
-                  :kaocha.type.scenari/glue-paths    ["test/scenario/glue"]
-                  :kaocha.type.scenari/feature-paths ["resources/scenarios"]}]}
+                  :kaocha.type.scenari/glue-paths    ["test/scenario/glue"]}]}
 ```
 You are able to launch your scenario using kaocha repl utility function
 

--- a/src/kaocha/type/scenari.clj
+++ b/src/kaocha/type/scenari.clj
@@ -1,5 +1,6 @@
 (ns kaocha.type.scenari
-  (:require [clojure.test :as t]
+  (:require [clojure.string :as string]
+            [clojure.test :as t]
             [clojure.string :as str]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
@@ -9,8 +10,7 @@
             [kaocha.repl :as krepl]
             [scenari.v2.core :as v2]
             [scenari.v2.core :as sc]
-            [scenari.v2.test])
-  (:import (org.apache.commons.io FileUtils)))
+            [scenari.v2.test]))
 
 (s/def :kaocha.type/scenari (s/keys :req [:kaocha/source-paths
                                           :kaocha/test-paths]))
@@ -19,25 +19,13 @@
   (or (io/file (io/resource path))
       (io/file path)))
 
-(defn find-feature-in-dir [path source]
+(defn find-features-meta-in-dir [path]
   (->> path
        path->file
        ns-find/find-namespaces-in-dir
        (map #(ns-publics (symbol %)))
        (mapcat #(map meta (vals %)))
-       (filter #(= (:scenari/raw-feature %) source))))
-
-(defn find-feature-in-dirs [paths source]
-  (mapcat #(find-feature-in-dir % source) paths))
-
-(defn paths->documents [paths]
-  (->> paths
-       (map path->file)
-       (mapcat #(FileUtils/listFiles % (into-array ["story" "feature"]) true))
-       (filter #(str/ends-with? (.getName %) ".feature"))
-       (map (fn [feature-path] {:path   (.getPath feature-path)
-                                :file   (.getName feature-path)
-                                :scenari/raw-feature (slurp feature-path)}))))
+       (filter #(:scenari/raw-feature %))))
 
 (defn path->id [path]
   (-> path
@@ -67,15 +55,6 @@
           ::file          (str (:project-directory document) (:file document))
           }))
 
-(defn feature->testable [testable document]
-  (let [feature-meta (first (find-feature-in-dirs (::glue-paths testable) (:scenari/raw-feature document))) ;TODO handle exception when multiple deffeature match
-        {{:keys [feature scenarios pre-run]} :scenari/feature-ast} feature-meta]
-    {::testable/type         :kaocha.type/scenari-feature
-     ::testable/id           (keyword (path->id (str (:project-directory document) (:file document))))
-     ::testable/desc         feature
-     :kaocha.test-plan/tests (mapv #(scenario->testable document %) scenarios)
-     ::pre-run               pre-run}))
-
 (defn- require-all-ns [paths]
   (->> paths
        (map path->file)
@@ -84,9 +63,16 @@
 
 (defmethod testable/-load :kaocha.type/scenari [testable]
   (require-all-ns (::glue-paths testable))
-  (let [documents (paths->documents (::feature-paths testable))]
-    (-> testable
-        (assoc :kaocha.test-plan/tests (mapv #(feature->testable testable %) documents)))))
+  (let [tests (for [test-path (:kaocha/test-paths testable)
+                    {{:keys [feature scenarios pre-run]} :scenari/feature-ast
+                     feature-content                     :scenari/raw-feature
+                     :as                                 feature-meta} (find-features-meta-in-dir test-path)]
+                {::testable/type         :kaocha.type/scenari-feature
+                 ::testable/id           (keyword (str (:ns feature-meta)) (str (:name feature-meta)))
+                 ::testable/desc         feature
+                 :kaocha.test-plan/tests (mapv #(scenario->testable feature-content %) scenarios)
+                 ::pre-run               pre-run})]
+    (assoc testable :kaocha.test-plan/tests tests)))
 
 (defmethod testable/-run :kaocha.type/scenari [testable test-plan]
   (let [results (testable/run-testables (:kaocha.test-plan/tests testable) test-plan)
@@ -130,7 +116,6 @@
     testable))
 
 (s/def ::glue-paths (s/coll-of string?))
-(s/def ::feature-paths (s/coll-of string?))
 
 (s/def :kaocha.type/scenari (s/keys :req [:kaocha/source-paths
                                           :kaocha/test-paths
@@ -166,31 +151,4 @@
                              :type                         :kaocha.type/scenari
                              :kaocha/source-paths          ["src"]
                              :kaocha/test-paths            ["test/scenari/v2"]
-                             :scenari.v2.kaocha/glue-paths ["test/scenari/v2"]}]})
-
-
-  (-> (find-feature-in-dirs ["test/scenari/v2"] "Feature: foo bar kix\n\n  Scenario: create a new product\n    When I invoke a GET request on location URL\n     # this is a comment\n    When I create a new product with name \"iphone 6\" and description \"awesome phone\" with properties\n      | size | weight |\n      | 6    | 2      |\n    Then I receive a response with an id 56422\n    Then a location URL\n  Scenario: another\n    Given I foo\n\n")
-      first
-      (get-in [:feature-ast :scenarios]))
-
-  (feature->testable
-    {::glue-paths ["test/scenari/v2"]}
-    {:path              "/Users/davidpanza/Workspace/defsquare/scenari/test/scenari/v2/example.feature",
-     :project-directory "test/scenari/v2/",
-     :file              "example.feature",
-     :source            "Feature: foo bar kix
-
-             Scenario: create a new product
-               When I invoke a GET request on location URL
-                # this is a comment
-               When I create a new product with name \"iphone 6\" and description \"awesome phone\" with properties
-                 | size | weight |
-                 | 6    | 2      |
-               Then I receive a response with an id 56422
-               Then a location URL
-             Scenario: another
-               Given I foo
-
-           "})
-
-  )
+                             :scenari.v2.kaocha/glue-paths ["test/scenari/v2"]}]}))

--- a/src/scenari/meta.clj
+++ b/src/scenari/meta.clj
@@ -3,6 +3,6 @@
 
 (def module-name "scenari")
 (def path ".")
-(def version "2.0.0")
-(def tag "v2.0.0")
-(def generated-at "2025-08-28T13:00:00Z")
+(def version "2.0.1")
+(def tag "v2.0.1")
+(def generated-at "2025-09-16T13:00:00Z")

--- a/test/scenari/v2/feature_test.clj
+++ b/test/scenari/v2/feature_test.clj
@@ -5,8 +5,7 @@
             [kaocha.type.scenari]
             [scenari.v2.some-glue-ns]
             [kaocha.repl :as krepl]
-            [testit.core :refer :all])
-  (:import (java.io StringWriter)))
+            [testit.core :refer :all]))
 
 (def side-effect-atom (atom 0))
 (def scenario-side-effect-atom (atom 0))
@@ -66,7 +65,6 @@
   (v2/run-features)
   (v2/run-features #'scenari.v2.feature-test/my-feature)
   (sc-test/run-features #'scenari.v2.feature-test/short-feature)
-
   (krepl/test-plan)
   (krepl/run-all)
   (krepl/run :scenario))

--- a/tests.edn
+++ b/tests.edn
@@ -3,8 +3,7 @@
                         :type                           :kaocha.type/scenari
                         :kaocha/source-paths            ["src"]
                         :kaocha/test-paths              ["test/scenari/v2"]
-                        :kaocha.type.scenari/glue-paths ["scenari/v2"]
-                        :kaocha.type.scenari/feature-paths ["scenari/v2"]}
+                        :kaocha.type.scenari/glue-paths ["scenari/v2"]}
                        
                        {:id                :unit
                         :type              :kaocha.type/clojure.test


### PR DESCRIPTION
Fix kaocha test load phase by finding deffeature inside :kaocha/test-paths

We used to read feature files inside `:kaocha.type.scenari/feature-paths` defined in kaocha config, then match `deffeature` inside `:kaocha/test-paths`. But we could have feature file without a `deffeature` defined, that makes an error when loading test. Now we map only test from `deffeature`